### PR TITLE
Add dev flag to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 You can install the package via composer:
 
 ```bash
-composer require spatie/laravel-error-solutions
+composer require --dev spatie/laravel-error-solutions
 ```
 
 You can publish the config file with:


### PR DESCRIPTION
Updates the composer require command to use `--dev` and avoid extra an extra prompt

## Current state

The command in the docs generates the followng output:
```bash
/var/www/html/laravel-solutions $ composer require spatie/laravel-error-solutions
The package you required is recommended to be placed in require-dev (because it is tagged as "dev") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]?
``` 
## Proposal

Once the package is `tagged as dev` using the flag will prevent an extra user prompt