### PR TITLE
Fix cmd to publish vendor views

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ return [
 Optionally, you can publish the views using
 
 ```bash
-php artisan vendor:publish --tag="laravel-error-solutions-views"
+php artisan vendor:publish --tag="error-solutions-views"
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the github readme to fix the ` vendor:publish`  views cmd.

## Current state

The command in the docs generates the followng output:
```bash
/var/www/html/laravel-solutions $ php artisan vendor:publish --tag="laravel-error-solutions-views"

   INFO  No publishable resources for tag [laravel-error-solutions-views]. 
``` 
## Proposal

The following update fix the issue and do publish the views.
