### PR TITLE
Add information about publishing views into docs page

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -59,3 +59,10 @@ return [
     'runnable_solutions_guard' => Spatie\LaravelErrorSolutions\Support\RunnableSolutionsGuard::class,
 ];
 ```
+## Publishing the views files
+
+Optionally, you can publish the views using
+
+```bash
+php artisan vendor:publish --tag="error-solutions-views"
+```


### PR DESCRIPTION
Add information about publishing views into docs page

Currently the github readme.md [shows how to publish the vendor views][], but this information was missing in the [docs pages].

this PR set the docs align 


[shows how to publish the vendor views]: https://github.com/spatie/laravel-error-solutions/blob/783d1e5c0b4b5cac525d8308a7d78c7d56e44645/README.md?plain=1#L64
[docs pages]: https://spatie.be/docs/laravel-error-solutions/v1/installation-setup#content-publishing-the-config-file-1

