### PR TITLE
Fix syntax issue in getSolution snippet

### DIFF
--- a/docs/creating-your-own-solutions/on-exceptions.md
+++ b/docs/creating-your-own-solutions/on-exceptions.md
@@ -60,7 +60,7 @@ class ExceptionWithSolution extends Exception implements ProvidesSolution
 
     public function getSolution(): Solution
     {
-        return YourSolution::class,
+        return new MySolution();
     }
 }
 ```


### PR DESCRIPTION
Fixes the syntax issue and uses same Solution class name created previously.