### PR TITLE
Add missing required dep spatie/backtrace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^11.13.0",
+        "spatie/backtrace": "^1.6",
         "spatie/error-solutions": "^1.0.4",
         "spatie/laravel-package-tools": "^1.16.4"
     },


### PR DESCRIPTION
## Issue Context

AI provided solution are not been loaded due an error on calling `Backtrace::createForThrowable`.

## Fix Context

1.  The file `OpenAiSolution` need to use [Spatie\Backtrace\Backtrace::createForThrowable][] to proper handler the backtrace. 
2. Once `spatie/backtrace` is not present in the final installation the `OpenAiSolution` is not loaded due an exception.
3. Probably the `SolutionProviderRepository.php` is [intentionally suppressing this issue][]
4. The PR proposes add `spatie/backtrace`  as required dep because is lighter than add the whole `spatie/laravel-ray`

[Spatie\Backtrace\Backtrace::createForThrowable]: https://github.com/spatie/error-solutions/blob/83411415b324580a451f15cf5f2314b5acd782d9/src/Solutions/OpenAi/OpenAiSolution.php#L108C31-L108C51
[intentionally suppressing this issue]: https://github.com/spatie/error-solutions/blob/83411415b324580a451f15cf5f2314b5acd782d9/src/SolutionProviderRepository.php#L58