### PR TITLE
(Laravel 12.25 support) Update to include new exceptionAsMarkdown value

### DIFF
--- a/src/SpatieRenderer.php
+++ b/src/SpatieRenderer.php
@@ -17,10 +17,17 @@ class SpatieRenderer extends Renderer
             $this->htmlErrorRenderer->render($throwable),
         );
 
+        $exception = new Exception($flattenException, $request, $this->listener, $this->basePath);
+
+        $exceptionAsMarkdown = $this->viewFactory->make('laravel-exceptions-renderer::markdown', [
+            'exception' => $exception,
+        ])->render();
+
         self::$latestThrowable = $throwable;
 
         return $this->viewFactory->make('laravel-exceptions-renderer::show', [
-            'exception' => new Exception($flattenException, $request, $this->listener, $this->basePath),
+            'exception' => $exception,
+            'exceptionAsMarkdown' => $exceptionAsMarkdown,
         ])->render();
     }
 }


### PR DESCRIPTION
Laravel 12.25 introduced a new button on the exception page to copy the exception as markdown, which involves passing a new `exceptionAsMarkdown` value to the rendered view.

As this package doesn't do that, it means using this package on Laravel 12.25 shows a different Whoops exception page for this issue. All I have done in this PR is pull in the updated code from the base class.