### PR TITLE
Update to support new Laravel 12.29 error page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.13.0|^12.0",
+        "illuminate/contracts": "^12.29",
         "spatie/backtrace": "^1.6",
         "spatie/error-solutions": "^2.0.1",
         "spatie/laravel-package-tools": "^1.16.4"
@@ -29,7 +29,7 @@
         "laravel/pint": "^1.16.1",
         "nunomaduro/collision": "^8.1.1",
         "larastan/larastan": "^2.9.7|^3.0",
-        "orchestra/testbench": "^9.1.2|^10.0",
+        "orchestra/testbench": "^10.0",
         "pestphp/pest": "^2.34.8|^3.0",
         "pestphp/pest-plugin-arch": "^2.7|^3.0",
         "pestphp/pest-plugin-laravel": "^2.4|^3.0",

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,29 +1,34 @@
-<x-laravel-exceptions-renderer::card>
-    <div class="md:flex md:items-center md:justify-between md:gap-2">
-        <div class="min-w-0">
-            <div class="inline-block rounded-full bg-red-500/20 px-3 py-2 max-w-full text-sm font-bold leading-5 text-red-500 truncate lg:text-base dark:bg-red-500/20">
-                <span class="hidden md:inline">
-                    {{ $exception->class() }}
-                </span>
-                <span class="md:hidden">
-                    {{ implode(' ', array_slice(explode('\\', $exception->class()), -1)) }}
-                </span>
-            </div>
-            <div class="mt-4 text-lg font-semibold text-gray-900 break-words dark:text-white lg:text-2xl">
-                {{ $exception->message() }}
-            </div>
-        </div>
+@props(['exception'])
 
-        <div class="hidden text-right shrink-0 md:block md:min-w-64 md:max-w-80">
-            <div>
-                <span class="inline-block rounded-full bg-gray-200 px-3 py-2 text-sm leading-5 text-gray-900 max-w-full truncate dark:bg-gray-800 dark:text-white">
-                    {{ $exception->request()->method() }} {{ $exception->request()->httpHost() }}
-                </span>
+<div class="flex flex-col pt-8 sm:pt-16 overflow-x-auto">
+    <div class="flex flex-col gap-5 mb-8">
+        <h1 class="text-3xl font-semibold text-neutral-950 dark:text-white">{{ $exception->class() }}</h1>
+        <p class="text-xl font-light text-neutral-800 dark:text-neutral-300">
+            {{ $exception->message() }}
+        </p>
+    </div>
+
+    <x-laravel-exceptions-renderer::solution />
+
+    <div class="flex items-start gap-2 mb-8 sm:mb-16">
+        <div class="bg-white dark:bg-white/[3%] border border-neutral-200 dark:border-white/10 divide-x divide-neutral-200 dark:divide-white/10 rounded-md shadow-xs flex items-center gap-0.5">
+            <div class="flex items-center gap-1.5 h-6 px-[6px] font-mono text-[13px]">
+                <span class="text-neutral-400 dark:text-neutral-500">LARAVEL</span>
+                <span class="text-neutral-500 dark:text-neutral-300">{{ app()->version() }}</span>
             </div>
-            <div class="px-4">
-                <span class="text-sm text-gray-500 dark:text-gray-400">PHP {{ PHP_VERSION }} — Laravel {{ app()->version() }}</span>
+            <div class="flex items-center gap-1.5 h-6 px-[6px] font-mono text-[13px]">
+                <span class="text-neutral-400 dark:text-neutral-500">PHP</span>
+                <span class="text-neutral-500 dark:text-neutral-300">{{ PHP_VERSION }}</span>
             </div>
         </div>
+        <x-laravel-exceptions-renderer::badge type="error">
+            <x-laravel-exceptions-renderer::icons.alert class="w-2.5 h-2.5" />
+            UNHANDLED
+        </x-laravel-exceptions-renderer::badge>
+        <x-laravel-exceptions-renderer::badge type="error" variant="solid">
+            CODE {{ $exception->code() }}
+        </x-laravel-exceptions-renderer::badge>
     </div>
-    <x-laravel-exceptions-renderer::solution />
-</x-laravel-exceptions-renderer::card>
+
+    <x-laravel-exceptions-renderer::request-url :request="$exception->request()" class="relative z-50" />
+</div>

--- a/resources/views/components/solution.blade.php
+++ b/resources/views/components/solution.blade.php
@@ -3,119 +3,34 @@
 @endphp
 
 @if(count($solutions))
-    <style>
-        .solution {
-            margin: 1.5rem -1.5rem -1.5rem;
-            padding: 1.5rem;
-            border-radius: 0 0 8px 8px;
-            background-color: #d6eed1;
-        }
-
-        .dark .solution {
-            background-color: #60755b;
-        }
-
-        @media (min-width: 640px) {
-            .solution {
-                margin: 3rem -3rem -3rem;
-                padding: 3rem;
-            }
-        }
-
-        .solution h2 {
-            font-size: 1.25rem;
-            font-weight: bold;
-        }
-
-        .solution h2 + p {
-            font-size: 1.25rem;
-        }
-
-        .solution h3 {
-            text-transform: uppercase;
-            margin-top: 1.5rem;
-            font-weight: bold;
-            font-size: 0.85rem;
-            letter-spacing: 0.015em;
-        }
-
-        .solution hr {
-            margin: 3.5rem 0 2.5rem;
-            border-top: 2px solid #b7d2b1;
-        }
-
-        .solution a {
-            text-decoration: underline;
-        }
-
-        .execute-solution {
-            margin-top: 3rem;
-        }
-
-        .execute-solution form {
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-        }
-
-        .execute-solution button {
-            display: flex;
-            align-items: center;
-            gap: 1ch;
-            font-size: 1.125rem;
-            font-weight: 500;
-            background-color: #b7d2b1;
-            padding: 1rem 1.5rem;
-            border-radius: 100px;
-            transition: background-color 0.15s ease-in-out;
-            white-space: nowrap;
-        }
-
-        .execute-solution button:hover {
-            background-color: #b0c8aa;
-        }
-
-        .dark .execute-solution button {
-            background-color: #424b40;
-        }
-
-        .dark .execute-solution button:hover {
-            background-color: #364233;
-        }
-
-        .execute-solution button svg {
-            height: 1.2em;
-        }
-
-        .solution-provider {
-            margin-top: 3rem;
-            opacity: 0.8;
-            font-size: 0.875rem;
-            text-align: right;
-        }
-    </style>
-    <div class="solution">
+    <div class="flex flex-col gap-5 bg-neutral-50 dark:bg-white/1 border border-neutral-200 dark:border-neutral-800 rounded-xl p-5 shadow-xs mb-8 sm:mb-16">
         @foreach($solutions as $solution)
-            <h2>{{ $solution->getSolutionTitle() }}{{ str_ends_with($solution->getSolutionTitle(), '.') ? '' : '.' }}</h2>
-            <p>{{ $solution->getSolutionDescription() }}</p>
+            <div class="flex items-center gap-2.5">
+                <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-white/5 rounded-md w-6 h-6 flex items-center justify-center p-1">
+                    <x-laravel-exceptions-renderer::icons.info class="w-2.5 h-2.5 text-blue-500 dark:text-emerald-500" />
+                </div>
+                <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">{{ $solution->getSolutionTitle() }}{{ str_ends_with($solution->getSolutionTitle(), '.') ? '' : '.' }}</h2>
+            </div>
+            <p class="text-base text-neutral-500 dark:text-neutral-400">{{ $solution->getSolutionDescription() }}</p>
 
             @if(count($solution->getDocumentationLinks()))
-                <h3>Read more</h3>
-                <ul>
-                    @foreach($solution->getDocumentationLinks() as $label => $url)
-                        <li>
-                            <a href="{{ $url }}" target="_blank" rel="nofollow noreferer">
-                                {{ $label }}
-                            </a>
-                        </li>
-                    @endforeach
-                </ul>
+                <div class="flex flex-col gap-1.5">
+                    <h3 class="font-semibold text-sm uppercase">Read more</h3>
+                    <ul class="flex flex-col gap-1.5">
+                        @foreach($solution->getDocumentationLinks() as $label => $url)
+                            <li>
+                                <a href="{{ $url }}" target="_blank" rel="nofollow noreferer" class="hover:underline decoration-neutral-400 text-neutral-500 dark:text-neutral-400">
+                                    {{ $label }}
+                                </a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
             @endif
 
             @if(config('error-solutions.enable_runnable_solutions'))
                 @if($solution instanceof \Spatie\ErrorSolutions\Contracts\RunnableSolution)
                     <div
-                        class="execute-solution"
                         x-data="{
                             solutionExecuted: false,
                             submitForm() {
@@ -134,10 +49,10 @@
                             }
                         }"
                     >
-                        <form x-show="! solutionExecuted" @submit.prevent="submitForm()">
-                            <button type="submit">
+                        <form x-show="! solutionExecuted" x-on:submit.prevent="submitForm()" class="flex items-center gap-5">
+                            <button type="submit" class="text-sm rounded-md border px-3 flex items-center gap-2 transition-colors duration-200 ease-in-out cursor-pointer shadow-xs text-neutral-600 dark:text-neutral-400 bg-white/5 border-neutral-200 hover:bg-neutral-100 dark:bg-white/5 dark:border-white/10 dark:hover:bg-white/10" style="padding-top: 0.25rem; padding-bottom: 0.25rem;">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                     stroke-width="1.5" stroke="currentColor">
+                                     stroke-width="1.5" stroke="currentColor" class="h-3 w-3">
                                     <path stroke-linecap="round" stroke-linejoin="round"
                                           d="M21.75 6.75a4.5 4.5 0 0 1-4.884 4.484c-1.076-.091-2.264.071-2.95.904l-7.152 8.684a2.548 2.548 0 1 1-3.586-3.586l8.684-7.152c.833-.686.995-1.874.904-2.95a4.5 4.5 0 0 1 6.336-4.486l-3.276 3.276a3.004 3.004 0 0 0 2.25 2.25l3.276-3.276c.256.565.398 1.192.398 1.852Z"/>
                                     <path stroke-linecap="round" stroke-linejoin="round"
@@ -145,26 +60,26 @@
                                 </svg>
                                 {{ $solution->getRunButtonText() }}
                             </button>
-                            <p>{{ $solution->getSolutionActionDescription() }}</p>
+                            <p class="text-base text-neutral-500 dark:text-neutral-400">{{ $solution->getSolutionActionDescription() }}</p>
                         </form>
 
-                        <form x-show="solutionExecuted" @submit.prevent="location.reload()">
-                            <button type="submit">
+                        <form x-show="solutionExecuted" x-on:submit.prevent="location.reload()" class="flex items-center gap-5">
+                            <button type="submit" class="text-sm rounded-md border px-3 flex items-center gap-2 transition-colors duration-200 ease-in-out cursor-pointer shadow-xs text-neutral-600 dark:text-neutral-400 bg-white/5 border-neutral-200 hover:bg-neutral-100 dark:bg-white/5 dark:border-white/10 dark:hover:bg-white/10" style="padding-top: 0.25rem; padding-bottom: 0.25rem;">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                     stroke-width="1.5" stroke="currentColor">
+                                     stroke-width="1.5" stroke="currentColor" class="h-3 w-3">
                                     <path stroke-linecap="round" stroke-linejoin="round"
                                           d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"/>
                                 </svg>
                                 Refresh page
                             </button>
-                            <p>The solution was executed.</p>
+                            <p class="text-base text-neutral-500 dark:text-neutral-400">The solution was executed.</p>
                         </form>
                     </div>
                 @endif
             @endif
 
             @if(method_exists($solution, 'solutionProvidedByName'))
-                <p class="solution-provider">
+                <p class="text-sm text-right text-neutral-500 dark:text-neutral-400">
                     @if(method_exists($solution, 'solutionsProvidedByLink'))
                         Solution provided by <a
                             href="{{ $solution->solutionsProvidedByLink() }}">{{ $solution->solutionProvidedByName() }}</a>.


### PR DESCRIPTION
Mentioned [a couple of weeks ago](https://x.com/taylorotwell/status/1967967314948788331), Laravel 12.29 ships with a new error page that unfortunately breaks this package - it has different styles, views and dependency versions.

In this merge request I've done a few things:

1. Used the Tailwind utilities (and general component styles) from the new error page to style the solution panel
2. Updated `@submit.prevent` to `x-on:submit.prevent` to work with the Alpine provided
3. Updated the `header.blade.php` to be a straight copy of the equivalent file from the new error page from laravel/framework, and inserted the solution component this package provides at an equivalent point

Here are some screenshots showing how the new solution panel looks. I didn't try to do anything fancy, it's just reusing equivalent styles from the new error page to get something working.

<img width="2032" height="1192" alt="image" src="https://github.com/user-attachments/assets/5666a73a-0316-4edc-903d-3e8963f528ce" />

<img width="2032" height="1192" alt="image" src="https://github.com/user-attachments/assets/e4ea7cfe-7bc9-4244-9f48-1704feacacc7" />

Solves https://github.com/spatie/laravel-error-solutions/issues/24